### PR TITLE
Add default to supported locales when deciding which locale should be chosen.

### DIFF
--- a/packages/react-t/src/hooks/useLocale.ts
+++ b/packages/react-t/src/hooks/useLocale.ts
@@ -15,8 +15,13 @@ export default function useLocale({
 }): string | null {
   const documentLocale = useDocumentLocale();
 
+  let supportedLocalesWithDefault = supportedLocales;
+  if (defaultLocale) {
+    supportedLocalesWithDefault = [...supportedLocales, defaultLocale];
+  }
+
   if (propsLocale) {
-    const matchingPropsLocale = getMatchingLocale([propsLocale], supportedLocales);
+    const matchingPropsLocale = getMatchingLocale([propsLocale], supportedLocalesWithDefault);
 
     if (matchingPropsLocale) {
       return matchingPropsLocale;
@@ -24,7 +29,7 @@ export default function useLocale({
   }
 
   if (documentLocale) {
-    const matchingDocumentLocale = getMatchingLocale([documentLocale], supportedLocales);
+    const matchingDocumentLocale = getMatchingLocale([documentLocale], supportedLocalesWithDefault);
 
     if (matchingDocumentLocale) {
       return matchingDocumentLocale;
@@ -32,7 +37,7 @@ export default function useLocale({
   }
 
   const userLocales = getUserLocales();
-  const matchingUserLocale = getMatchingLocale(userLocales, supportedLocales);
+  const matchingUserLocale = getMatchingLocale(userLocales, supportedLocalesWithDefault);
 
   if (matchingUserLocale) {
     return matchingUserLocale;


### PR DESCRIPTION
Added default to supported locales when deciding which locale should be chosen.

Previously, if a locale was default, but not provided in languageFiles, then the program would prioritize languageFiles locales over the default locale, and only use the default locale if no other option was available.
This resulted in choosing a locale that was farther down on the list of preferences, over a preferred default locale.

This proposed change brings behavior of this project in line with the documentation, since README states:

> On each step, React-T checks if a given locale is supported (provided in languageFiles, or defined as defaultLocale).
